### PR TITLE
Add a 'version' option, so that a version can be specified to 'finddeps'

### DIFF
--- a/lib/CPAN/FindDependencies.pm
+++ b/lib/CPAN/FindDependencies.pm
@@ -194,7 +194,7 @@ sub finddeps {
     }
 
     my $version;
-    if ($opts{version}) {
+    if (!defined($opts{version})) {
         $version = $opts{version};
     }
     elsif ($p->package($module)) {


### PR DESCRIPTION
The ability to specify a version is useful since some software relies on specific versions of cpan modules. If the cpan module is not present for the specified version, an error is thrown as normal; but if it does exist on CPAN, that particular version is pulled instead of the latest to ensure compatibility with the software.
