### PR TITLE
bump min requirement of YAML::Tiny to 1.57

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,7 @@ WriteMakefile(
   PREREQ_PM    => {
     'Parse::CPAN::Packages' => 2.31,
     'Module::CoreList'      => 2.90,
-    'YAML::Tiny'            => 1.36,
+    'YAML::Tiny'            => 1.57,
     'LWP::UserAgent'        => 0,
     'Scalar::Util'          => 1.14,
     'URI::file'             => 4.13,


### PR DESCRIPTION
I find YAML::Tiny < 1.57 is not able to parse some recent META.yml files, like the ones for Try-Tiny/0.27 and Moose/2.1805